### PR TITLE
Bugfix and additional init and install scripts.

### DIFF
--- a/classes/Client/Storage/Abstract.php
+++ b/classes/Client/Storage/Abstract.php
@@ -57,6 +57,7 @@ abstract class dropr_Client_Storage_Abstract
             // Guess the classname from the dsn
             $className = 'dropr_Client_Storage_' . ucfirst($type);
             self::$instances[$dsn] = new $className($dsn);
+            self::$instances[$dsn]->dsn = $dsn;
         }
         
         return self::$instances[$dsn];

--- a/client/bin/dropr.cfg-default.rhel
+++ b/client/bin/dropr.cfg-default.rhel
@@ -1,0 +1,9 @@
+SPOOLDIR=/var/spool/dropr/client/
+PIDDIR=/var/run/dropr
+PIDFILE=$PIDDIR/$NAME.pid
+
+BIN=_THISPATH_
+RUN=$BIN/client_queue.php
+DAEMON=$BIN/$NAME
+
+LOG_LEVEL=INFO

--- a/client/bin/dropr.init.rhel
+++ b/client/bin/dropr.init.rhel
@@ -1,0 +1,129 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          skeleton
+# Required-Start:    $local_fs $remote_fs
+# Required-Stop:     $local_fs $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Example initscript
+# Description:       This file should be used to construct scripts to be
+#                    placed in /etc/init.d.
+### END INIT INFO
+
+#
+# dropr
+#
+# Copyright (c) 2007 - 2008 by the dropr project https://www.dropr.org/
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#   * Neither the name of dropr nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# @package    dropr
+# @author     Soenke Ruempler <soenke@jimdo.com>
+# @author     Boris Erdmann <boris@jimdo.com>
+# @copyright  2007-2008 Soenke Ruempler, Boris Erdmann
+# @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+
+# Please remove the "Author" lines above and replace them
+# with your own name if you copy and modify this script.
+
+# Do NOT "set -e"
+
+# Source function library
+. /etc/rc.d/init.d/functions
+
+# PATH should only include /usr/* if it runs after the mountnfs.sh script
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="DROPR client spool service"
+
+NAME=droprd
+CONFIG="/etc/dropr.cfg"
+
+DAEMON=/usr/sbin/$NAME
+DAEMON_ARGS="$CONFIG"
+
+PIDFILE=/var/run/dropr/$NAME.pid
+
+SCRIPTNAME=/etc/init.d/$NAME
+
+CWD=`dirname "$CONFIG"`
+if [ -e "$CONFIG" ]
+then
+    . "$CONFIG"
+else
+    if [ -e /etc/dropr.cfg ]
+    then
+        . /etc/dropr.cfg
+    fi
+fi
+
+RETVAL=0
+
+start() {
+    echo -n $"Starting $NAME: " 
+    daemon --user apache $DAEMON "$DAEMON_ARGS" &
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && touch /var/lock/subsys/$NAME
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Stopping $NAME: " 
+    killall -TERM $NAME
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/$NAME
+    return $RETVAL
+} 
+
+restart() {
+    stop
+    start
+}    
+
+case "$1" in
+    start)
+        start
+    ;;
+    stop)
+        stop
+    ;;
+    status)
+        ps aux | egrep -e"$NAME|_queue" | grep -v grep
+    ;;
+    reload|restart|force-reload)
+        restart
+    ;;
+    *)
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart}" >&2
+	exit 3
+    ;;
+esac

--- a/client/bin/install.rhel.sh
+++ b/client/bin/install.rhel.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+#
+# dropr
+#
+# Copyright (c) 2008, by the dropr project https://www.dropr.org/
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#   * Neither the name of dropr nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# @package    dropr
+# @author     Soenke Ruempler <soenke@jimdo.com>
+# @author     Boris Erdmann <boris@jimdo.com>
+# @copyright  2007-2008 Soenke Ruempler, Boris Erdmann
+# @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+
+CWD="`pwd`"
+
+INITSCRIPT="$CWD/dropr.init.rhel"
+CONFIG="$CWD/dropr.cfg-default.rhel"
+
+if [ -e "$CONFIG" ]
+then
+  . "$CONFIG"
+
+  case "$1" in
+    remove)
+      /etc/init.d/dropr stop
+      chkconfig dropr off
+      echo                 
+      rm -f /etc/init.d/dropr
+      rm -f /etc/dropr.cfg
+      echo
+    ;;
+    *)
+
+      mkdir -p $SPOOLDIR/in
+      mkdir -p $SPOOLDIR/proc
+      mkdir -p $SPOOLDIR/sent
+      mkdir -p $PIDDIR
+
+      chown -R apache:apache $PIDDIR
+      chmod -R ug+rwx $SPOOLDIR
+      chown -R apache:apache $SPOOLDIR
+
+      cp $INITSCRIPT /etc/init.d/dropr
+      sed -e "s|_THISPATH_|$CWD|g" <$CONFIG >/etc/dropr.cfg
+
+      echo
+      chkconfig dropr on
+      echo
+    ;;
+   esac
+
+else
+  echo "$CONFIG missing."
+  echo "Could not install/remove."
+fi


### PR DESCRIPTION
find attached a set of init and config scripts for redhat based
distros. The start/stop script does not use a PID in lack of a real
start-stop-daemon binary in RHEL, but it works, albeit crude. Feel
free to use for improvement :-)

the other commit is a small bugfix for the ipc mechanism
